### PR TITLE
Allow server ID input for recurring invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Recurring Billing pro okokBilling s ox_target
 
 Tento resource přidává jednoduchý systém měsíčních faktur napojený na [`okokBilling`](https://okok.tebex.io/).
-Správci mohou přes stolní interakci z `ox_target` otevřít formulář z `ox_lib`, vyplnit identifier hráče ve tvaru `charX:Y`
-a částku, a skript následně každý měsíc automaticky vytvoří fakturu přes okokBilling.
+Správci mohou přes stolní interakci z `ox_target` otevřít formulář z `ox_lib`, vyplnit aktuální serverové ID online hráče
+nebo jeho identifier ve tvaru `charX:Y` a částku, a skript následně každý měsíc automaticky vytvoří fakturu přes okokBilling.
 
 ## Funkce
 
@@ -27,8 +27,16 @@ a částku, a skript následně každý měsíc automaticky vytvoří fakturu p�
 ## Použití
 
 1. Přijdi k definovanému stolu a stiskni interakci `ox_target`.
-2. Vyplň identifier hráče ve tvaru `charX:Y` (např. `char1:42`), částku v Kč/$ a případně vlastní label faktury.
-3. Po potvrzení se položka uloží a skript začne fakturovat každý měsíc.
+2. Vyplň buď aktuální serverové ID online hráče (např. `23`), nebo jeho `char` identifier (např. `char1:42`), částku v Kč/$ a
+   případně vlastní label faktury.
+3. Pokud zadáš serverové ID, skript se pokusí najít online hráče a automaticky převést jeho identifier na `charX:Y`. Jestliže
+   hráč není online, musíš jeho `char` identifier zadat ručně.
+4. Po potvrzení se položka uloží a skript začne fakturovat každý měsíc.
+
+### Příklady zadání
+
+- `17` – vytvoří fakturu pro hráče se serverovým ID 17, pokud je online a má platný identifier `charX:Y`.
+- `char2:15` – vytvoří fakturu pro daný identifier, vhodné pro offline hráče nebo pokud znáš konkrétní postavu.
 
 > Faktury se vytváří stejným způsobem, jako kdyby byly ručně vytvořeny v UI okokBilling.
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -16,9 +16,9 @@ local function openRecurringDialog()
     local input = lib.inputDialog('Nová termínová platba', {
         {
             type = 'input',
-            label = 'Identifier hráče',
-            description = 'Zadej identifier ve tvaru char1:1',
-            placeholder = 'char1:1',
+            label = 'Hráč (server ID nebo charX:Y)',
+            description = 'Zadej aktuální serverové ID online hráče nebo jeho char identifier (např. 12 nebo char1:1).',
+            placeholder = '12 nebo char1:1',
             required = true
         },
         {
@@ -41,9 +41,9 @@ local function openRecurringDialog()
         return
     end
 
-    local identifier = input[1] and input[1]:lower() or ''
-    if not identifier:match('^char%d+:%d+$') then
-        notifyError('Identifier musí být ve tvaru charX:Y (např. char1:1).')
+    local identifier = input[1]
+    if type(identifier) ~= 'string' or identifier == '' then
+        notifyError('Musíš zadat serverové ID nebo identifier hráče.')
         return
     end
 


### PR DESCRIPTION
## Summary
- allow the client dialog to request a server ID or char identifier and forward the raw value
- resolve numeric inputs on the server to char identifiers via ESX with improved error handling
- document the new workflow and provide examples in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e19beecef083308da6ad57087f8740