### PR TITLE
Ensure ESX is loaded before recurring billing logic

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -24,5 +24,6 @@ server_scripts {
 dependencies {
     'ox_lib',
     'ox_target',
-    'okokBilling'
+    'okokBilling',
+    'es_extended'
 }


### PR DESCRIPTION
## Summary
- fetch the ESX shared object on resource startup using exports with an event fallback
- reuse the cached ESX instance when validating numeric identifiers for recurring invoices
- declare es_extended as an explicit dependency to load after ESX

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a0dd00948330926c3abd200fa412